### PR TITLE
Fix mobile firefox css

### DIFF
--- a/Assets/style.css
+++ b/Assets/style.css
@@ -583,7 +583,7 @@ nav {
 	left: 0;
 	width: 260px;
 	height: 100%;
-	min-height: 100vh;
+
 	background-color: var( --color-chalk );
 	padding: 0 0 8rem 0;
 	overflow: auto;
@@ -1667,11 +1667,10 @@ header h1 svg {
 	body nav {
 
 		position: fixed;
-		bottom: 0 !important;
 		left: 0;
 		width: 100%;
 		height: fit-content;
-		min-height: 0;
+		height: -moz-fit-content;
 		padding: 0;
 		margin: 0;
 		box-shadow: 0 0 0.5rem rgba( 0, 0, 0, 0.5 );


### PR DESCRIPTION
The site was all white besides the logo on Firefox on Android (and desktop firefox if the site is really narrow).  Turns out the nav css was broken since `height: fit-content` doesn't work on firefox, so i made a couple of tweaks to make it work.  Also tested on narrow-Chrome to make sure i didn't break something there.

Before -> After
![Screenshot 2019-11-21 at 8 57 07 PM](https://user-images.githubusercontent.com/161135/69399134-db7ea700-0ca1-11ea-9359-042cff2d9512.png)
